### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import re
 import psycopg2
 from psycopg2.extras import RealDictCursor
-
+import logging
 from flask import Flask, render_template, request, redirect, url_for, session, flash, jsonify
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_caching import Cache
@@ -662,7 +662,8 @@ def reorder_services():
         return jsonify({'success': True})
     except Exception as e:
         conn.rollback()
-        return jsonify({'error': str(e)}), 500
+        logging.error("Error in reorder_services: %s", str(e))
+        return jsonify({'error': 'An internal error has occurred!'}), 500
     finally:
         conn.close()
 
@@ -704,7 +705,8 @@ def reorder_default_services():
         return jsonify({'success': True})
     except Exception as e:
         conn.rollback()
-        return jsonify({'error': str(e)}), 500
+        logging.error("Error in reorder_default_services: %s", str(e))
+        return jsonify({'error': 'An internal error has occurred!'}), 500
     finally:
         conn.close()
 


### PR DESCRIPTION
Potential fix for [https://github.com/DrewWilliamsCRC/frontend_site/security/code-scanning/5](https://github.com/DrewWilliamsCRC/frontend_site/security/code-scanning/5)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the line that returns the exception message with a line that logs the exception and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
