### PR TITLE
refactor: Update CI workflow to run tests only on pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,8 +23,9 @@ env:
   PYTHON_VERSION: 3.10-alpine
 
 jobs:
-  # Python unit testing
+  # Python unit testing - only run on PRs
   python-tests:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -111,8 +112,9 @@ jobs:
             echo "Python tests failed but we'll continue with Docker tests"
           fi
 
-  # Database migration tests
+  # Database migration tests - only run on PRs
   db-migration-tests:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: python-tests
     services:
@@ -682,8 +684,8 @@ jobs:
   publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [python-tests, db-migration-tests]
-    # Add timeout to prevent CI from abandoning long-running builds
+    # Remove dependency on test jobs since they won't run on push to main
+    # needs: [python-tests, db-migration-tests]
     timeout-minutes: 45
     env:
       # Enable pushing to Docker Hub for publish job only


### PR DESCRIPTION
- Added conditional checks to ensure Python unit tests and database migration tests only execute on pull request events.
- Removed dependencies on test jobs for the publish job, as they are not applicable during pushes to the main branch.